### PR TITLE
Fix typos in both nested menu examples on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ var Example = React.createClass({
 
   render: function() {
     var menuOptions = {
-      isOpen: this.state.isOpen,
+      isOpen: this.state.isMenuOpen,
       close: this.close,
       toggle: <button type="button" onClick={this.toggle}>Click me!</button>,
       align: 'right'
@@ -246,7 +246,7 @@ class Example extends React.Component {
 
   render() {
     const menuOptions = {
-      isOpen: this.state.isOpen,
+      isOpen: this.state.isMenuOpen,
       close: this.close,
       toggle: <button type="button" onClick={this.toggle}>Click me!</button>,
       align: 'right',


### PR DESCRIPTION
`this.state.isOpen` should actually read `this.state.isMenuOpen`. These typos prevent the examples from running when copied and pasted.